### PR TITLE
Relbits is an experiment in key compaction.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OPTFLAGS=-O3 -fomit-frame-pointer -funroll-loops -fstrict-aliasing -march=native -mtune=native -msse4.2 -mavx
+OPTFLAGS=-O3 -fomit-frame-pointer -funroll-loops -fstrict-aliasing -march=native -mtune=native -msse4.2 -mbmi2 -mavx
 WARNFLAGS=-Wall -Wextra -Wshadow -Wstrict-aliasing -Wcast-qual -Wcast-align -Wpointer-arith -Wredundant-decls -Wfloat-equal -Wswitch-enum
 MISCFLAGS=-fstack-protector -fvisibility=hidden
 DEVFLAGS=-Wno-unused-parameter -Wno-unused-variable
@@ -11,6 +11,12 @@ CXXFLAGS=-std=gnu++17 -fno-rtti $(OPTFLAGS) $(WARNFLAGS) $(MISCFLAGS)
 
 lutbs-test: lutbs-test.cpp lutbs.hpp
 	$(CXX) $(CXXFLAGS) $< -o $@
+
+relbits: relbits.cpp
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+#abstest: abstest.cpp lutbs.hpp
+#	$(CXX) $(CXXFLAGS) $< -o $@
 
 .PHONY: clean bench
 

--- a/lutbs-test.cpp
+++ b/lutbs-test.cpp
@@ -23,6 +23,8 @@
 #include <limits>
 #include <vector>
 
+using namespace basic_kdfs;
+
 template<typename L=size_t, typename T, typename KeyFunc = decltype(kdf<T>)>
 const std::vector<L> build_bs_lut(int lutbits, const T *arr, size_t len, uint8_t extra_shift = 0, KeyFunc && kf = kdf) {
 	const size_t lutlen = 1UL << lutbits;

--- a/lutbs.hpp
+++ b/lutbs.hpp
@@ -5,9 +5,11 @@
 #include <type_traits>
 #include <algorithm>
 
+namespace basic_kdfs {
+
 // Helper template to return an unsigned T with the MSB set.
 template<typename T>
-std::enable_if_t<std::is_integral_v<T>, typename std::make_unsigned<T>::type>
+std::enable_if_t<std::is_integral_v<T>, typename std::make_unsigned_t<T>>
 constexpr highbit(void) {
 	return 1ULL << ((sizeof(T) << 3) - 1);
 }
@@ -19,7 +21,7 @@ kdf(const T& value) {
 };
 
 // The std::conditional is needed because std::make_unsigned<T> does not support non-integral types
-template<typename T, typename KT=std::conditional<std::is_integral<T>::value,std::make_unsigned<T>,std::common_type<T>>>
+template<typename T, typename KT=std::conditional<std::is_integral_v<T>,std::make_unsigned<T>,std::common_type<T>>>
 std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T> && !std::is_same_v<T,bool>, typename KT::type::type>
 kdf(const T& value) {
 	return value ^ highbit<T>();
@@ -39,4 +41,6 @@ kdf(const T& value) {
 	KT local;
 	std::memcpy(&local, &value, sizeof(local));
 	return local ^ (-(local >> 63UL) | (1UL << 63UL));
+}
+
 }

--- a/relbits.cpp
+++ b/relbits.cpp
@@ -1,0 +1,83 @@
+
+#include <cstdio>
+#include <cinttypes>
+#include <cstdint>
+#include <cstring>
+#include <cassert>
+
+#include <immintrin.h>
+
+#include <random>
+#include <algorithm>
+#include <limits>
+#include <vector>
+#include <array>
+#include <iostream>
+#include <bitset>
+
+#include "lutbs.hpp"
+
+using namespace basic_kdfs;
+
+template <typename T, typename GenFunc>
+const std::vector<T> random_array(size_t len, GenFunc && gen) {
+	std::vector<T> arr(len);
+
+	std::generate_n(begin(arr), len, gen);
+
+	return arr;
+}
+
+template <
+	typename T, typename KeyFunc = decltype(kdf<T>), typename KeyType=typename std::result_of_t<KeyFunc&&(T)>
+>
+auto relevant_bits(T *arr, size_t n, KeyFunc && kf = kdf) {
+	KeyType acc_zeroes(0);
+	KeyType acc_ones(~0);
+
+	for (size_t i = 0 ; i < n ; ++i) {
+		auto val = kf(arr[i]);
+		acc_zeroes |= val;
+		acc_ones   &= val;
+	}
+
+	// std::cout << "acc_zeroes = " << std::bitset<std::numeric_limits<T>::digits>(acc_zeroes) << "\n";
+	// std::cout << "acc_ones   = " << std::bitset<std::numeric_limits<T>::digits>(acc_ones) << "\n";
+
+	KeyType mask = ~(~acc_zeroes | acc_ones);
+
+	return mask;
+}
+
+template <typename T, typename KeyFunc = decltype(kdf<T>)>
+void demo(T *arr, size_t n, KeyFunc && kf = kdf) {
+
+	auto mask = relevant_bits(arr, n, kf);
+
+	std::cout << "mask   = " << std::bitset<std::numeric_limits<typeof(mask)>::digits>(mask) << "\n";
+
+	// popcnt on the ~mask gives us the best 'compression' we can achieve.
+	// and could provide an 'early out'. We only care about the thresholds 8, 16 and 24 since this saves us a pass each.
+	// worst case 16-bits->8 bits: 1010101010101010 -> 0000000011111111
+	for (size_t i = 0 ; i < n ; ++i) {
+		auto value = kf(arr[i]);
+		printf("[%zu] %08x -> %08x\n", i, value, _pext_u32(value, mask));
+	}
+
+
+}
+
+int main(int argc, char *argv[]) {
+	std::array<uint32_t,7> ua = { 255, 42, 1, 0, 1, 42, (1L << 31) + 255 };
+	std::array<int32_t,7> sa = { -255, -42, -1, 0, 1, 42, 255 };
+	// std::array<float,11> fa = { 128.0f, 646464.0f, 1.987654321f, 0.0f, -0.0f, -0.5f, 0.5f, -128.0f, -INFINITY, NAN, INFINITY };
+	std::array<float,6> fa = { 0.9f, 0.1f, 1.0f, 0.5f, 0.25f, 0.33333333f };
+
+	// GOAL: generate a mask + shift array to reduce a value to its 'relevant' bits.
+	// worst case there are log2(T)/2 shift/mask ops per value required.
+	// DONE: SUB-GOAL #1: Find all bit positions where all values have the same bit set or unset.
+	demo(ua.data(), ua.size());
+	demo(fa.data(), fa.size());
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Basically we can scan the input data and use PEXT to compress
the keys such that irrelevant bits -- those that does not influence
the relative order of all the values if they are removed -- can
be ignored.

This has applications in radix sorting and LUTed binary search
which also relies on bucketing.